### PR TITLE
Fix SessionStart and Stop to show Done instead of Waiting for input

### DIFF
--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -89,7 +89,7 @@ describe("HTTP Server", () => {
     const sessions = await fetch(port, "GET", "/api/sessions");
     const list = JSON.parse(sessions.body);
     assert.equal(list.length, 1);
-    assert.equal(list[0].status, "waiting");
+    assert.equal(list[0].status, "done");
   });
 
   it("POST /api/hook with invalid JSON returns 400", async () => {

--- a/src/state.test.ts
+++ b/src/state.test.ts
@@ -8,14 +8,14 @@ describe("createStore", () => {
     assert.deepStrictEqual(store.getAllSessions(), []);
   });
 
-  it("SessionStart creates a session with status waiting", () => {
+  it("SessionStart creates a session with status done", () => {
     const store = createStore();
     const session = store.handleEvent({
       session_id: "s1",
       hook_event_name: "SessionStart",
       cwd: "/home/user/project",
     });
-    assert.equal(session?.status, "waiting");
+    assert.equal(session?.status, "done");
     assert.equal(session?.sessionId, "s1");
     assert.equal(session?.cwd, "/home/user/project");
     assert.equal(session?.lastEvent, "SessionStart");
@@ -31,7 +31,7 @@ describe("createStore", () => {
     assert.equal(session?.status, "running");
   });
 
-  it("Stop transitions to waiting", () => {
+  it("Stop transitions to done", () => {
     const store = createStore();
     store.handleEvent({ session_id: "s1", hook_event_name: "SessionStart" });
     store.handleEvent({
@@ -42,7 +42,7 @@ describe("createStore", () => {
       session_id: "s1",
       hook_event_name: "Stop",
     });
-    assert.equal(session?.status, "waiting");
+    assert.equal(session?.status, "done");
   });
 
   it("SessionEnd removes session and returns null", () => {
@@ -78,7 +78,7 @@ describe("createStore", () => {
     const s1 = store.getSession("s1");
     const s2 = store.getSession("s2");
     assert.equal(s1?.status, "running");
-    assert.equal(s2?.status, "waiting");
+    assert.equal(s2?.status, "done");
   });
 
   it("unknown session_id creates new session", () => {

--- a/src/state.ts
+++ b/src/state.ts
@@ -25,9 +25,9 @@ export interface Store {
 }
 
 const EVENT_TO_STATUS: Record<string, SessionStatus> = {
-  SessionStart: "waiting",
+  SessionStart: "done",
   UserPromptSubmit: "running",
-  Stop: "waiting",
+  Stop: "done",
 };
 
 export function createStore(): Store {


### PR DESCRIPTION
## Summary
- Changed `EVENT_TO_STATUS` mapping so `SessionStart` and `Stop` events map to `"done"` instead of `"waiting"`
- When a session starts or Claude finishes processing, the dashboard now correctly shows **"Done"** (idle/ready) rather than the misleading **"Waiting for input"**
- Updated all related test expectations in `state.test.ts` and `server.test.ts`

Fixes #2

## Test plan
- [x] `npm test` — all 71 tests pass
- [x] `npm run build` — builds successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)