### PR TITLE
Add automatic PR creation to release-version-sync workflow

### DIFF
--- a/.github/workflows/release-version-sync.yml
+++ b/.github/workflows/release-version-sync.yml
@@ -19,6 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pull-requests: write
     env:
       BRANCH: ${{ github.event_name == 'push' && github.ref_name || github.event.pull_request.head.ref }}
     steps:
@@ -72,5 +73,22 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add package.json package-lock.json
-          git commit -m "Release: $VERSION [skip ci]"
+          git commit -m "Release: $VERSION"
           git push
+
+      - name: Create or update pull request
+        if: github.event_name == 'push'
+        run: |
+          VERSION="${{ steps.branch.outputs.version }}"
+          EXISTING=$(gh pr list --head "${{ env.BRANCH }}" --base master --json number -q '.[0].number')
+          if [ -n "$EXISTING" ]; then
+            echo "PR #$EXISTING already exists for this branch."
+          else
+            gh pr create \
+              --base master \
+              --head "${{ env.BRANCH }}" \
+              --title "Release: $VERSION" \
+              --body "Automated release PR for v$VERSION."
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Adds a "Create or update pull request" step to the `release-version-sync` workflow that automatically opens a PR from `release/*` branches to `master` after version sync
- Adds `pull-requests: write` permission to the workflow job
- Handles idempotency: detects existing PRs and skips creation to avoid duplicates
- Only runs on `push` events (not `pull_request`) to prevent loops

## Test plan
- [ ] Push a `release/x.y.z` branch — workflow should sync version, commit, and open a PR to `master`
- [ ] Push again to the same branch — workflow should detect existing PR and skip creation
- [ ] Verify the `release.yml` workflow still triggers correctly on merged release PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)