### PR TITLE
Use GitHub App token for release workflow CI triggers

### DIFF
--- a/.github/workflows/release-version-sync.yml
+++ b/.github/workflows/release-version-sync.yml
@@ -27,6 +27,13 @@ jobs:
         with:
           ref: ${{ env.BRANCH }}
 
+      - name: Generate App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - uses: actions/setup-node@v4
         with:
           node-version: 24
@@ -75,6 +82,8 @@ jobs:
           git add package.json package-lock.json
           git commit -m "Release: $VERSION"
           git push
+        env:
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
 
       - name: Create or update pull request
         if: github.event_name == 'push'
@@ -91,4 +100,4 @@ jobs:
               --body "Automated release PR for v$VERSION."
           fi
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
## Summary

- Use a GitHub App token (via `actions/create-github-app-token@v1`) instead of `GITHUB_TOKEN` for git push and PR creation in the `release-version-sync` workflow
- Fixes CI not triggering on bot-created release PRs — GitHub suppresses workflow triggers for events created by `GITHUB_TOKEN` to prevent infinite loops
- Both `push` (triggers `pull_request: synchronize`) and `gh pr create` (triggers `pull_request: opened`) now use the App token so CI runs in all cases

## Test plan

- [ ] Push a test release branch (e.g. `release/0.0.5`) and verify the Release Version Sync workflow runs
- [ ] Verify CI triggers on the newly created PR
- [ ] Verify status checks appear on the PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)