### PR TITLE
Fix release chain: use App token in release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,12 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@v4
+      - name: Generate App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
       - name: Get version from package.json
         id: version
         run: echo "version=$(jq -r .version package.json)" >> "$GITHUB_OUTPUT"
@@ -26,4 +32,4 @@ jobs:
           --generate-notes
           --latest
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
## Summary
- Use GitHub App token instead of `GITHUB_TOKEN` in `release.yml` for the `gh release create` step
- This fixes `publish.yml` never triggering after a release is created, because GitHub Actions suppresses events from `GITHUB_TOKEN`
- Same fix already applied to `release-version-sync.yml` in commit `5d62a41`

## Test plan
- [ ] Merge this PR into `master`
- [ ] Create and merge a `release/*` PR
- [ ] Verify `release.yml` creates the GitHub release
- [ ] Verify `publish.yml` is triggered by the `release: [published]` event and publishes to npm

🤖 Generated with [Claude Code](https://claude.com/claude-code)