### PR TITLE
Fix ghost session created by Ping health-check event

### DIFF
--- a/src/state.test.ts
+++ b/src/state.test.ts
@@ -147,6 +147,33 @@ describe("createStore", () => {
     assert.equal(session?.lastEvent, "PreToolUse");
   });
 
+  it("Ping event does not create a session and returns null", () => {
+    const store = createStore();
+    const result = store.handleEvent({
+      session_id: "s1",
+      hook_event_name: "Ping",
+    });
+    assert.equal(result, null);
+    assert.equal(store.getAllSessions().length, 0);
+  });
+
+  it("Ping event does not modify an existing session", () => {
+    const store = createStore();
+    store.handleEvent({
+      session_id: "s1",
+      hook_event_name: "SessionStart",
+      cwd: "/project",
+    });
+    const result = store.handleEvent({
+      session_id: "s1",
+      hook_event_name: "Ping",
+    });
+    assert.equal(result, null);
+    const session = store.getSession("s1");
+    assert.equal(session?.status, "done");
+    assert.equal(session?.lastEvent, "SessionStart");
+  });
+
   it("handles unknown event gracefully", () => {
     const store = createStore();
     const session = store.handleEvent({

--- a/src/state.ts
+++ b/src/state.ts
@@ -43,6 +43,10 @@ export function createStore(): Store {
         return null;
       }
 
+      if (hook_event_name === "Ping") {
+        return null;
+      }
+
       const status = EVENT_TO_STATUS[hook_event_name];
       if (!status) {
         const existing = sessions.get(session_id);


### PR DESCRIPTION
## Summary
- Ignore `Ping` health-check events in `handleEvent()` so they don't create phantom sessions with unknown cwd
- Fixes #18: Unknown session appearing on dashboard at startup

## Changes
- `src/state.ts`: Added early `return null` for `Ping` events, right after the existing `SessionEnd` check
- `src/state.test.ts`: Added 2 test cases covering Ping on non-existing and existing sessions

## Test plan
- [x] `npm test` — all 76 tests pass including 2 new Ping tests
- [x] `npm run lint` — no lint errors on changed files
- [x] `npm run build` — builds successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)