### PR TITLE
Add notification test banner (#24)

### DIFF
--- a/src/dashboard.test.ts
+++ b/src/dashboard.test.ts
@@ -99,4 +99,32 @@ describe("getDashboardHtml", () => {
     assert.ok(html.includes("setButtonsEnabled(false)"));
     assert.ok(html.includes("setButtonsEnabled(true)"));
   });
+
+  it("contains notification test banner container", () => {
+    assert.ok(html.includes('id="notifBanner"'));
+  });
+
+  it("contains notification banner CSS styles", () => {
+    assert.ok(html.includes(".notif-banner"));
+    assert.ok(html.includes(".notif-banner button"));
+  });
+
+  it("contains showNotifBanner and hideNotifBanner functions", () => {
+    assert.ok(html.includes("function showNotifBanner"));
+    assert.ok(html.includes("function hideNotifBanner"));
+  });
+
+  it("shows banner with test button when notifications toggled on", () => {
+    assert.ok(html.includes("Notifications enabled. Push button to test."));
+    assert.ok(html.includes('id="btnTestNotif"'));
+  });
+
+  it("fires test notification on button click", () => {
+    assert.ok(html.includes("Claude Code - Test"));
+    assert.ok(html.includes("Notifications are working!"));
+  });
+
+  it("auto-hides banner after 10 seconds", () => {
+    assert.ok(html.includes("setTimeout(hideNotifBanner, 10000)"));
+  });
 });


### PR DESCRIPTION
## Summary
- Adds a yellow info banner that appears below the header when notifications are toggled ON
- Banner shows "Notifications enabled. Push button to test." with a **Test** button that fires a browser notification
- Banner auto-disappears after 10 seconds; toggling notifications OFF hides it immediately
- Includes 6 new tests covering banner container, CSS, JS functions, test button, and auto-hide behavior

Closes #24

## Test plan
- [ ] Toggle notifications ON — yellow banner appears with "Test" button
- [ ] Click "Test" button — browser notification "Claude Code - Test" fires
- [ ] Wait 10 seconds — banner auto-disappears
- [ ] Toggle notifications OFF while banner is visible — banner hides immediately
- [ ] Toggle notifications ON/OFF rapidly — no timer leaks, banner behaves correctly
- [ ] Run `npm test` — all 84 tests pass
- [ ] Run `npm run lint` — no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)