### PR TITLE
Show tool name instead of UserPromptSubmit for non-interactive tools

### DIFF
--- a/src/hooks.test.ts
+++ b/src/hooks.test.ts
@@ -47,13 +47,13 @@ describe("installHooks", () => {
     assert.ok(settings.hooks.PreToolUse);
   });
 
-  it("PreToolUse hook has correct matcher for interactive tools", () => {
+  it("PreToolUse hook captures all tools without matcher", () => {
     installHooks(8377, tmpDir);
     const settings = readSettings() as HookSettings & {
       hooks: Record<string, Array<{ matcher?: string; hooks: Array<{ statusMessage: string }> }>>;
     };
     const group = settings.hooks.PreToolUse[0];
-    assert.equal(group.matcher, "ExitPlanMode|AskUserQuestion");
+    assert.equal(group.matcher, undefined);
     assert.equal(group.hooks[0].statusMessage, "__claude_code_dashboard_quick__");
   });
 

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -7,7 +7,6 @@ const MARKER_INSTALL = "__claude_code_dashboard_install__";
 const MARKER_LEGACY = "__claude_code_dashboard__";
 
 const HOOK_EVENTS = ["SessionStart", "UserPromptSubmit", "Stop", "SessionEnd"] as const;
-const INTERACTIVE_TOOLS_MATCHER = "ExitPlanMode|AskUserQuestion";
 
 interface HookEntry {
   type: string;
@@ -137,12 +136,11 @@ export function installHooks(port: number, configDir?: string): void {
     });
   }
 
-  // PreToolUse with matcher for interactive tools (plan approval, user questions)
+  // PreToolUse for all tools (captures tool name for dashboard display)
   if (!settings.hooks.PreToolUse) {
     settings.hooks.PreToolUse = [];
   }
   settings.hooks.PreToolUse.push({
-    matcher: INTERACTIVE_TOOLS_MATCHER,
     hooks: [
       {
         type: "command",
@@ -184,12 +182,11 @@ export function installHooksWithCommand(command: string, configDir?: string): vo
     });
   }
 
-  // PreToolUse with matcher for interactive tools (plan approval, user questions)
+  // PreToolUse for all tools (captures tool name for dashboard display)
   if (!settings.hooks.PreToolUse) {
     settings.hooks.PreToolUse = [];
   }
   settings.hooks.PreToolUse.push({
-    matcher: INTERACTIVE_TOOLS_MATCHER,
     hooks: [
       {
         type: "command",


### PR DESCRIPTION
## Summary
- Capture all `PreToolUse` events (removed matcher restriction) so the dashboard sees every tool invocation, not just `ExitPlanMode`/`AskUserQuestion`
- Display the actual tool name (Bash, Read, Write, etc.) as the last event instead of generic `UserPromptSubmit`
- Non-interactive tools now correctly show **running** status with the tool name, while interactive tools continue to show **waiting** status

Closes #23

## Test plan
- [x] All 87 existing + new tests pass (`npm test`)
- [x] Lint passes (`npm run lint`)
- [ ] Manual: start a Claude Code session, use Bash tool, verify dashboard shows "Bash" instead of "UserPromptSubmit"
- [ ] Manual: trigger AskUserQuestion, verify dashboard still shows "Waiting for input"