### PR TITLE
Fix Bash permission requests showing Running instead of Waiting for input

### DIFF
--- a/src/state.test.ts
+++ b/src/state.test.ts
@@ -158,10 +158,42 @@ describe("createStore", () => {
     const session = store.handleEvent({
       session_id: "s1",
       hook_event_name: "PreToolUse",
-      tool_name: "Bash",
+      tool_name: "Read",
     });
     assert.equal(session?.status, "running");
+    assert.equal(session?.lastEvent, "Read");
+  });
+
+  it("PreToolUse with Bash transitions to waiting", () => {
+    const store = createStore();
+    store.handleEvent({ session_id: "s1", hook_event_name: "SessionStart" });
+    store.handleEvent({
+      session_id: "s1",
+      hook_event_name: "UserPromptSubmit",
+    });
+    const session = store.handleEvent({
+      session_id: "s1",
+      hook_event_name: "PreToolUse",
+      tool_name: "Bash",
+    });
+    assert.equal(session?.status, "waiting");
     assert.equal(session?.lastEvent, "Bash");
+  });
+
+  it("PreToolUse with Write transitions to waiting", () => {
+    const store = createStore();
+    store.handleEvent({ session_id: "s1", hook_event_name: "SessionStart" });
+    store.handleEvent({
+      session_id: "s1",
+      hook_event_name: "UserPromptSubmit",
+    });
+    const session = store.handleEvent({
+      session_id: "s1",
+      hook_event_name: "PreToolUse",
+      tool_name: "Write",
+    });
+    assert.equal(session?.status, "waiting");
+    assert.equal(session?.lastEvent, "Write");
   });
 
   it("PreToolUse without tool_name falls back to PreToolUse display", () => {

--- a/src/state.ts
+++ b/src/state.ts
@@ -30,7 +30,14 @@ const EVENT_TO_STATUS: Record<string, SessionStatus> = {
   Stop: "done",
 };
 
-const INTERACTIVE_TOOLS = new Set(["ExitPlanMode", "AskUserQuestion"]);
+const INTERACTIVE_TOOLS = new Set([
+  "ExitPlanMode",
+  "AskUserQuestion",
+  "Bash",
+  "Write",
+  "Edit",
+  "NotebookEdit",
+]);
 
 export function createStore(): Store {
   const sessions = new Map<string, Session>();


### PR DESCRIPTION
## Summary
- Add `Bash`, `Write`, `Edit`, and `NotebookEdit` to the `INTERACTIVE_TOOLS` set so their `PreToolUse` events produce `status: "waiting"` instead of `"running"`
- Dashboard now correctly shows "Waiting for input" when Claude Code asks for tool permission approval
- Notifications now fire for these permission prompts, alerting users when action is needed

Closes #29

## Test plan
- [x] All 89 tests pass (`npm test`)
- [x] Lint clean on modified files (`npm run lint`)
- [x] New tests verify `Bash` and `Write` PreToolUse → waiting transition
- [x] Existing non-interactive test updated to use `Read` instead of `Bash`
- [x] Manual: confirm dashboard shows "Waiting for input" when Bash permission prompt appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)