### PR TITLE
Add version display to dashboard header

### DIFF
--- a/src/bin.ts
+++ b/src/bin.ts
@@ -1,10 +1,25 @@
 import { exec, spawn } from "node:child_process";
+import { readFileSync } from "node:fs";
 import * as http from "node:http";
 import * as net from "node:net";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 import { installHooks, removeHooks } from "./hooks.ts";
 import { install, readLockFile, removeLockFile, uninstall, writeLockFile } from "./installer.ts";
 import { createServer } from "./server.ts";
 import { createStore } from "./state.ts";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+function readVersion(): string | undefined {
+  try {
+    const pkg = JSON.parse(readFileSync(join(__dirname, "..", "package.json"), "utf-8"));
+    return pkg.version;
+  } catch {
+    return undefined;
+  }
+}
 
 const DEFAULT_PORT = 8377;
 
@@ -244,6 +259,7 @@ function main(): void {
 
 function startDashboard(port: number, noHooks: boolean, noOpen: boolean): void {
   const store = createStore();
+  const version = readVersion();
 
   let cleanedUp = false;
   function cleanup() {
@@ -263,6 +279,7 @@ function startDashboard(port: number, noHooks: boolean, noOpen: boolean): void {
 
   const dashboard = createServer({
     store,
+    version,
     onShutdown() {
       cleanup();
       process.exit(0);

--- a/src/dashboard.test.ts
+++ b/src/dashboard.test.ts
@@ -127,4 +127,14 @@ describe("getDashboardHtml", () => {
   it("auto-hides banner after 10 seconds", () => {
     assert.ok(html.includes("setTimeout(hideNotifBanner, 10000)"));
   });
+
+  it("includes version badge when version is provided", () => {
+    const htmlWithVersion = getDashboardHtml("1.2.3");
+    assert.ok(htmlWithVersion.includes("1.2.3"));
+    assert.ok(htmlWithVersion.includes("version-badge"));
+  });
+
+  it("omits version badge element when no version is provided", () => {
+    assert.ok(!html.includes('<span class="version-badge">'));
+  });
 });

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -1,4 +1,4 @@
-export function getDashboardHtml(): string {
+export function getDashboardHtml(version?: string): string {
   return `<!DOCTYPE html>
 <html lang="en">
 <head>
@@ -29,6 +29,13 @@ export function getDashboardHtml(): string {
     font-size: 20px;
     font-weight: 600;
     color: #f0f6fc;
+  }
+
+  .version-badge {
+    font-size: 12px;
+    font-weight: 400;
+    color: #6e7681;
+    margin-left: 8px;
   }
 
   .header-right {
@@ -399,7 +406,7 @@ export function getDashboardHtml(): string {
 </head>
 <body>
 <header>
-  <h1>Claude Code Dashboard</h1>
+  <h1>Claude Code Dashboard${version ? `<span class="version-badge">v${version}</span>` : ""}</h1>
   <div class="header-right">
     <div class="notification-toggle">
       <label class="toggle-switch">

--- a/src/server.ts
+++ b/src/server.ts
@@ -10,6 +10,7 @@ export interface DashboardServer {
 
 export interface ServerOptions {
   store: Store;
+  version?: string;
   idleTimeoutMs?: number;
   cleanupIntervalMs?: number;
   onShutdown?: () => void;
@@ -17,7 +18,7 @@ export interface ServerOptions {
 }
 
 export function createServer(options: ServerOptions): DashboardServer {
-  const { store, onShutdown, onRestart } = options;
+  const { store, version, onShutdown, onRestart } = options;
   const idleTimeoutMs = options.idleTimeoutMs ?? 5 * 60 * 1000;
   const cleanupIntervalMs = options.cleanupIntervalMs ?? 60_000;
   const sseClients = new Set<http.ServerResponse>();
@@ -38,7 +39,7 @@ export function createServer(options: ServerOptions): DashboardServer {
 
     if (req.method === "GET" && pathname === "/") {
       res.writeHead(200, { "Content-Type": "text/html; charset=utf-8" });
-      res.end(getDashboardHtml());
+      res.end(getDashboardHtml(version));
       return;
     }
 


### PR DESCRIPTION
## Summary
- Reads the package version from `package.json` at startup and passes it through `createServer()` → `getDashboardHtml()`
- Displays the version as a subtle muted badge (`v0.0.7`) next to the dashboard title in the header
- Gracefully handles missing `package.json` (version badge simply not shown)

Closes #22

## Test plan
- [x] `npm test` — 91 tests pass (2 new version badge tests)
- [x] `npm run build` — builds successfully
- [x] `npm run lint` — no issues
- [ ] Visual: verify version badge appears in dashboard header

🤖 Generated with [Claude Code](https://claude.com/claude-code)