### PR TITLE
Fix install to stop and uninstall before reinstalling

### DIFF
--- a/src/bin.ts
+++ b/src/bin.ts
@@ -199,12 +199,25 @@ function main(): void {
   const { port, command, noHooks, noOpen } = parseArgs(process.argv);
 
   if (command === "install") {
-    install(port);
+    (async () => {
+      await stopServer();
+      uninstall();
+      install(port);
+    })().catch((err) => {
+      console.error("Install failed:", err);
+      process.exit(1);
+    });
     return;
   }
 
   if (command === "uninstall") {
-    uninstall();
+    (async () => {
+      await stopServer();
+      uninstall();
+    })().catch((err) => {
+      console.error("Uninstall failed:", err);
+      process.exit(1);
+    });
     return;
   }
 


### PR DESCRIPTION
## Summary
- The `install` command now runs `stop` → `uninstall` → `install` to ensure the new version propagates immediately after installation
- The `uninstall` command now stops the running server before uninstalling
- Both commands include `.catch()` error handling for robustness

Closes #32

## Test plan
- [x] All 89 existing tests pass
- [x] Lint passes
- [x] Manual: run `install` while dashboard is already running — verify old process stops, old installation removed, new version installed
- [x] Manual: run `uninstall` while dashboard is running — verify server stops before hooks/files are removed