### PR TITLE
Add version display to dashboard header

### DIFF
--- a/src/dashboard.test.ts
+++ b/src/dashboard.test.ts
@@ -10,6 +10,11 @@ describe("getDashboardHtml", () => {
     assert.ok(html.includes("</html>"));
   });
 
+  it("contains version display in header", () => {
+    assert.ok(html.includes('class="version"'));
+    assert.match(html, /v\w+/);
+  });
+
   it("contains EventSource for SSE", () => {
     assert.ok(html.includes("EventSource"));
     assert.ok(html.includes("/api/events"));

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -1,4 +1,15 @@
+declare const __VERSION__: string;
+
+function getVersion(): string {
+  try {
+    return __VERSION__;
+  } catch {
+    return "dev";
+  }
+}
+
 export function getDashboardHtml(): string {
+  const version = getVersion();
   return `<!DOCTYPE html>
 <html lang="en">
 <head>
@@ -29,6 +40,13 @@ export function getDashboardHtml(): string {
     font-size: 20px;
     font-weight: 600;
     color: #f0f6fc;
+  }
+
+  .version {
+    font-size: 12px;
+    font-weight: 400;
+    color: #6e7681;
+    margin-left: 8px;
   }
 
   .header-right {
@@ -399,7 +417,7 @@ export function getDashboardHtml(): string {
 </head>
 <body>
 <header>
-  <h1>Claude Code Dashboard</h1>
+  <h1>Claude Code Dashboard <span class="version">v${version}</span></h1>
   <div class="header-right">
     <div class="notification-toggle">
       <label class="toggle-switch">

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,4 +1,7 @@
+import { readFileSync } from "node:fs";
 import { defineConfig } from "tsup";
+
+const pkg = JSON.parse(readFileSync("./package.json", "utf-8"));
 
 export default defineConfig({
   entry: ["src/bin.ts"],
@@ -8,5 +11,8 @@ export default defineConfig({
   outExtension: () => ({ js: ".js" }),
   banner: {
     js: "#!/usr/bin/env node",
+  },
+  define: {
+    __VERSION__: JSON.stringify(pkg.version),
   },
 });


### PR DESCRIPTION
## Summary
- Injects package version at build time via tsup's `define` option, reading from `package.json`
- Displays the version (`v0.0.7`) in the dashboard header next to the title for debugging purposes
- Falls back to `"dev"` when running in unbundled test mode

## Test plan
- [x] All 90 existing tests pass
- [x] New test verifies version CSS class and pattern are present in dashboard HTML
- [x] Build succeeds and version `0.0.7` is correctly injected in `dist/bin.js`
- [x] Lint clean on changed files

Closes #22