### PR TITLE
Fix too many notifications for Bash commands

### DIFF
--- a/src/state.test.ts
+++ b/src/state.test.ts
@@ -164,7 +164,7 @@ describe("createStore", () => {
     assert.equal(session?.lastEvent, "Read");
   });
 
-  it("PreToolUse with Bash transitions to waiting", () => {
+  it("PreToolUse with Bash stays running", () => {
     const store = createStore();
     store.handleEvent({ session_id: "s1", hook_event_name: "SessionStart" });
     store.handleEvent({
@@ -176,7 +176,7 @@ describe("createStore", () => {
       hook_event_name: "PreToolUse",
       tool_name: "Bash",
     });
-    assert.equal(session?.status, "waiting");
+    assert.equal(session?.status, "running");
     assert.equal(session?.lastEvent, "Bash");
   });
 

--- a/src/state.ts
+++ b/src/state.ts
@@ -33,7 +33,6 @@ const EVENT_TO_STATUS: Record<string, SessionStatus> = {
 const INTERACTIVE_TOOLS = new Set([
   "ExitPlanMode",
   "AskUserQuestion",
-  "Bash",
   "Write",
   "Edit",
   "NotebookEdit",


### PR DESCRIPTION
## Summary
- Remove `Bash` from `INTERACTIVE_TOOLS` set so Bash `PreToolUse` events set status to `"running"` instead of `"waiting"`
- This prevents spurious "Waiting for input" desktop notifications for every auto-approved Bash command

Fixes #37

## Test plan
- [x] `npm test` — all 90 tests pass
- [x] Manual: start dashboard, run Claude Code session with Bash commands → status shows "Running" not "Waiting for input", no spurious notifications

🤖 Generated with [Claude Code](https://claude.com/claude-code)