### PR TITLE
Fix Bash not showing 'Waiting for input' when approval needed (#33)

### DIFF
--- a/src/hooks.test.ts
+++ b/src/hooks.test.ts
@@ -37,7 +37,7 @@ describe("installHooks", () => {
     assert.ok(settings.hooks);
   });
 
-  it("creates all 5 hook events including PreToolUse", () => {
+  it("creates all 7 hook events including PreToolUse, PermissionRequest, and PostToolUse", () => {
     installHooks(8377, tmpDir);
     const settings = readSettings() as { hooks: Record<string, unknown[]> };
     assert.ok(settings.hooks.SessionStart);
@@ -45,6 +45,8 @@ describe("installHooks", () => {
     assert.ok(settings.hooks.Stop);
     assert.ok(settings.hooks.SessionEnd);
     assert.ok(settings.hooks.PreToolUse);
+    assert.ok(settings.hooks.PermissionRequest);
+    assert.ok(settings.hooks.PostToolUse);
   });
 
   it("PreToolUse hook captures all tools without matcher", () => {

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -6,7 +6,14 @@ const MARKER_QUICK = "__claude_code_dashboard_quick__";
 const MARKER_INSTALL = "__claude_code_dashboard_install__";
 const MARKER_LEGACY = "__claude_code_dashboard__";
 
-const HOOK_EVENTS = ["SessionStart", "UserPromptSubmit", "Stop", "SessionEnd"] as const;
+const HOOK_EVENTS = [
+  "SessionStart",
+  "UserPromptSubmit",
+  "Stop",
+  "SessionEnd",
+  "PermissionRequest",
+  "PostToolUse",
+] as const;
 
 interface HookEntry {
   type: string;

--- a/src/state.test.ts
+++ b/src/state.test.ts
@@ -260,6 +260,110 @@ describe("createStore", () => {
     assert.equal(session?.status, "waiting");
   });
 
+  it("PermissionRequest transitions to waiting with tool name", () => {
+    const store = createStore();
+    store.handleEvent({ session_id: "s1", hook_event_name: "SessionStart" });
+    store.handleEvent({ session_id: "s1", hook_event_name: "UserPromptSubmit" });
+    store.handleEvent({ session_id: "s1", hook_event_name: "PreToolUse", tool_name: "Bash" });
+    assert.equal(store.getSession("s1")?.status, "running");
+    const session = store.handleEvent({
+      session_id: "s1",
+      hook_event_name: "PermissionRequest",
+      tool_name: "Bash",
+    });
+    assert.equal(session?.status, "waiting");
+    assert.equal(session?.lastEvent, "Bash");
+  });
+
+  it("PostToolUse transitions to running with tool name", () => {
+    const store = createStore();
+    store.handleEvent({ session_id: "s1", hook_event_name: "SessionStart" });
+    store.handleEvent({ session_id: "s1", hook_event_name: "UserPromptSubmit" });
+    store.handleEvent({ session_id: "s1", hook_event_name: "PreToolUse", tool_name: "Bash" });
+    store.handleEvent({
+      session_id: "s1",
+      hook_event_name: "PermissionRequest",
+      tool_name: "Bash",
+    });
+    assert.equal(store.getSession("s1")?.status, "waiting");
+    const session = store.handleEvent({
+      session_id: "s1",
+      hook_event_name: "PostToolUse",
+      tool_name: "Bash",
+    });
+    assert.equal(session?.status, "running");
+    assert.equal(session?.lastEvent, "Bash");
+  });
+
+  it("Full approval flow: PreToolUse → PermissionRequest → PostToolUse", () => {
+    const store = createStore();
+    store.handleEvent({ session_id: "s1", hook_event_name: "SessionStart" });
+    store.handleEvent({ session_id: "s1", hook_event_name: "UserPromptSubmit" });
+
+    const afterPre = store.handleEvent({
+      session_id: "s1",
+      hook_event_name: "PreToolUse",
+      tool_name: "Bash",
+    });
+    assert.equal(afterPre?.status, "running");
+
+    const afterPerm = store.handleEvent({
+      session_id: "s1",
+      hook_event_name: "PermissionRequest",
+      tool_name: "Bash",
+    });
+    assert.equal(afterPerm?.status, "waiting");
+
+    const afterPost = store.handleEvent({
+      session_id: "s1",
+      hook_event_name: "PostToolUse",
+      tool_name: "Bash",
+    });
+    assert.equal(afterPost?.status, "running");
+  });
+
+  it("Auto-approved flow: PreToolUse → PostToolUse (no PermissionRequest)", () => {
+    const store = createStore();
+    store.handleEvent({ session_id: "s1", hook_event_name: "SessionStart" });
+    store.handleEvent({ session_id: "s1", hook_event_name: "UserPromptSubmit" });
+
+    const afterPre = store.handleEvent({
+      session_id: "s1",
+      hook_event_name: "PreToolUse",
+      tool_name: "Bash",
+    });
+    assert.equal(afterPre?.status, "running");
+
+    const afterPost = store.handleEvent({
+      session_id: "s1",
+      hook_event_name: "PostToolUse",
+      tool_name: "Bash",
+    });
+    assert.equal(afterPost?.status, "running");
+  });
+
+  it("PermissionRequest without tool_name falls back to event name", () => {
+    const store = createStore();
+    store.handleEvent({ session_id: "s1", hook_event_name: "SessionStart" });
+    const session = store.handleEvent({
+      session_id: "s1",
+      hook_event_name: "PermissionRequest",
+    });
+    assert.equal(session?.status, "waiting");
+    assert.equal(session?.lastEvent, "PermissionRequest");
+  });
+
+  it("PostToolUse without tool_name falls back to event name", () => {
+    const store = createStore();
+    store.handleEvent({ session_id: "s1", hook_event_name: "SessionStart" });
+    const session = store.handleEvent({
+      session_id: "s1",
+      hook_event_name: "PostToolUse",
+    });
+    assert.equal(session?.status, "running");
+    assert.equal(session?.lastEvent, "PostToolUse");
+  });
+
   it("removeSession deletes an existing session", () => {
     const store = createStore();
     store.handleEvent({ session_id: "s1", hook_event_name: "SessionStart" });

--- a/src/state.ts
+++ b/src/state.ts
@@ -61,6 +61,14 @@ export function createStore(): Store {
         const toolName = typeof payload.tool_name === "string" ? payload.tool_name : "";
         displayEvent = toolName || hook_event_name;
         status = INTERACTIVE_TOOLS.has(toolName) ? "waiting" : "running";
+      } else if (hook_event_name === "PermissionRequest") {
+        const toolName = typeof payload.tool_name === "string" ? payload.tool_name : "";
+        displayEvent = toolName || hook_event_name;
+        status = "waiting";
+      } else if (hook_event_name === "PostToolUse") {
+        const toolName = typeof payload.tool_name === "string" ? payload.tool_name : "";
+        displayEvent = toolName || hook_event_name;
+        status = "running";
       } else {
         const mapped = EVENT_TO_STATUS[hook_event_name];
         if (!mapped) {


### PR DESCRIPTION
## Summary
- Register `PermissionRequest` and `PostToolUse` hook events to accurately detect when a tool needs user approval vs. is auto-approved
- `PermissionRequest` sets status to "waiting" (fires only when permission dialog is shown), `PostToolUse` resets to "running" (fires after tool completes)
- Fixes #33 without the false-positive regression from the previous approach of adding Bash to `INTERACTIVE_TOOLS`

## Test plan
- [ ] Run `npm test` — all 96 tests pass including 6 new tests
- [ ] Run `npm run lint` — no errors
- [ ] Start dashboard, trigger a Bash command needing approval → dashboard shows "Waiting for input"
- [ ] Auto-approved Bash command → dashboard stays "Running"
- [ ] Interactive tools (Write, Edit, AskUserQuestion) still show "Waiting for input"