### PR TITLE
Fix Bash launching notifications for every command

### DIFF
--- a/src/dashboard.test.ts
+++ b/src/dashboard.test.ts
@@ -58,6 +58,12 @@ describe("getDashboardHtml", () => {
     assert.ok(html.includes("claude-waiting-"));
   });
 
+  it("only notifies for interactive tools, not Bash", () => {
+    assert.ok(html.includes("NOTIFY_TOOLS"));
+    assert.ok(html.includes("NOTIFY_TOOLS[s.lastEvent]"));
+    assert.ok(html.includes("AskUserQuestion"));
+  });
+
   it("contains Stop and Restart buttons", () => {
     assert.ok(html.includes('id="btnStop"'));
     assert.ok(html.includes('id="btnRestart"'));

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -516,6 +516,7 @@ export function getDashboardHtml(): string {
 
   var STATUS_LABELS = { running: 'Running', waiting: 'Waiting for input', done: 'Done' };
   var STATUS_ORDER = { running: 0, waiting: 1, done: 2 };
+  var NOTIFY_TOOLS = { ExitPlanMode: 1, AskUserQuestion: 1, Write: 1, Edit: 1, NotebookEdit: 1 };
 
   function timeAgo(ts) {
     var diff = Math.floor((Date.now() - ts) / 1000);
@@ -582,7 +583,7 @@ export function getDashboardHtml(): string {
     }
     if (notificationsEnabled && 'Notification' in window && Notification.permission === 'granted') {
       newSessions.forEach(function(s) {
-        if (s.status === 'waiting' && previousStatuses[s.sessionId] !== 'waiting') {
+        if (s.status === 'waiting' && previousStatuses[s.sessionId] !== 'waiting' && NOTIFY_TOOLS[s.lastEvent]) {
           new Notification('Claude Code - Waiting for input', {
             body: folderName(s.cwd),
             tag: 'claude-waiting-' + s.sessionId


### PR DESCRIPTION
## Summary
- Only fire browser notifications for interactive tools (AskUserQuestion, Write, Edit, NotebookEdit, ExitPlanMode), not for routine Bash PermissionRequest events
- Dashboard card still correctly shows "Waiting for input" status for Bash permission prompts — only the browser notification is suppressed
- Adds `NOTIFY_TOOLS` whitelist in the frontend that mirrors the `INTERACTIVE_TOOLS` set from `state.ts`

Closes #42

## Test plan
- [x] All 104 tests pass
- [x] Lint passes
- [ ] Verify Bash commands no longer trigger browser notifications
- [ ] Verify AskUserQuestion/Write/Edit still trigger browser notifications
- [ ] Verify Bash permission requests still show "Waiting for input" on the dashboard card

🤖 Generated with [Claude Code](https://claude.com/claude-code)