### PR TITLE
Fix npm always-auth warning in CI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,7 +14,7 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
           cache: npm

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "license": "GPL-3.0-only",
   "repository": {
     "type": "git",
-    "url": "https://github.com/kosinal/claude-code-dashboard"
+    "url": "git+https://github.com/kosinal/claude-code-dashboard.git"
   },
   "homepage": "https://github.com/kosinal/claude-code-dashboard#readme",
   "bugs": {


### PR DESCRIPTION
## Summary
- Upgrade `actions/setup-node` from v4 to v6 to eliminate the `Unknown user config "always-auth"` warning emitted by npm 10+
- Normalize `repository.url` in package.json (auto-corrected by npm during publish)

## Test plan
- [x] Trigger the publish workflow and verify the `always-auth` warning no longer appears in job logs