### PR TITLE
Fix waiting status for auto-approved tools in acceptEdits mode

### DIFF
--- a/src/state.test.ts
+++ b/src/state.test.ts
@@ -180,7 +180,7 @@ describe("createStore", () => {
     assert.equal(session?.lastEvent, "Bash");
   });
 
-  it("PreToolUse with Write transitions to waiting", () => {
+  it("PreToolUse with Write transitions to waiting in default mode", () => {
     const store = createStore();
     store.handleEvent({ session_id: "s1", hook_event_name: "SessionStart" });
     store.handleEvent({
@@ -194,6 +194,76 @@ describe("createStore", () => {
     });
     assert.equal(session?.status, "waiting");
     assert.equal(session?.lastEvent, "Write");
+  });
+
+  it("PreToolUse with Edit stays running in acceptEdits mode", () => {
+    const store = createStore();
+    store.handleEvent({ session_id: "s1", hook_event_name: "SessionStart" });
+    store.handleEvent({ session_id: "s1", hook_event_name: "UserPromptSubmit" });
+    const session = store.handleEvent({
+      session_id: "s1",
+      hook_event_name: "PreToolUse",
+      tool_name: "Edit",
+      permission_mode: "acceptEdits",
+    });
+    assert.equal(session?.status, "running");
+    assert.equal(session?.lastEvent, "Edit");
+  });
+
+  it("PreToolUse with Write stays running in acceptEdits mode", () => {
+    const store = createStore();
+    store.handleEvent({ session_id: "s1", hook_event_name: "SessionStart" });
+    store.handleEvent({ session_id: "s1", hook_event_name: "UserPromptSubmit" });
+    const session = store.handleEvent({
+      session_id: "s1",
+      hook_event_name: "PreToolUse",
+      tool_name: "Write",
+      permission_mode: "acceptEdits",
+    });
+    assert.equal(session?.status, "running");
+    assert.equal(session?.lastEvent, "Write");
+  });
+
+  it("PreToolUse with NotebookEdit stays running in acceptEdits mode", () => {
+    const store = createStore();
+    store.handleEvent({ session_id: "s1", hook_event_name: "SessionStart" });
+    store.handleEvent({ session_id: "s1", hook_event_name: "UserPromptSubmit" });
+    const session = store.handleEvent({
+      session_id: "s1",
+      hook_event_name: "PreToolUse",
+      tool_name: "NotebookEdit",
+      permission_mode: "acceptEdits",
+    });
+    assert.equal(session?.status, "running");
+    assert.equal(session?.lastEvent, "NotebookEdit");
+  });
+
+  it("PreToolUse with AskUserQuestion still transitions to waiting in acceptEdits mode", () => {
+    const store = createStore();
+    store.handleEvent({ session_id: "s1", hook_event_name: "SessionStart" });
+    store.handleEvent({ session_id: "s1", hook_event_name: "UserPromptSubmit" });
+    const session = store.handleEvent({
+      session_id: "s1",
+      hook_event_name: "PreToolUse",
+      tool_name: "AskUserQuestion",
+      permission_mode: "acceptEdits",
+    });
+    assert.equal(session?.status, "waiting");
+    assert.equal(session?.lastEvent, "AskUserQuestion");
+  });
+
+  it("PreToolUse with Edit transitions to waiting in default mode", () => {
+    const store = createStore();
+    store.handleEvent({ session_id: "s1", hook_event_name: "SessionStart" });
+    store.handleEvent({ session_id: "s1", hook_event_name: "UserPromptSubmit" });
+    const session = store.handleEvent({
+      session_id: "s1",
+      hook_event_name: "PreToolUse",
+      tool_name: "Edit",
+      permission_mode: "default",
+    });
+    assert.equal(session?.status, "waiting");
+    assert.equal(session?.lastEvent, "Edit");
   });
 
   it("PreToolUse without tool_name falls back to PreToolUse display", () => {

--- a/src/state.ts
+++ b/src/state.ts
@@ -30,13 +30,9 @@ const EVENT_TO_STATUS: Record<string, SessionStatus> = {
   Stop: "done",
 };
 
-const INTERACTIVE_TOOLS = new Set([
-  "ExitPlanMode",
-  "AskUserQuestion",
-  "Write",
-  "Edit",
-  "NotebookEdit",
-]);
+const ALWAYS_INTERACTIVE_TOOLS = new Set(["ExitPlanMode", "AskUserQuestion"]);
+
+const EDIT_TOOLS = new Set(["Write", "Edit", "NotebookEdit"]);
 
 export function createStore(): Store {
   const sessions = new Map<string, Session>();
@@ -60,7 +56,14 @@ export function createStore(): Store {
       if (hook_event_name === "PreToolUse") {
         const toolName = typeof payload.tool_name === "string" ? payload.tool_name : "";
         displayEvent = toolName || hook_event_name;
-        status = INTERACTIVE_TOOLS.has(toolName) ? "waiting" : "running";
+        const permissionMode =
+          typeof payload.permission_mode === "string" ? payload.permission_mode : "";
+        const isEditAutoApproved = permissionMode === "acceptEdits" && EDIT_TOOLS.has(toolName);
+        status =
+          !isEditAutoApproved &&
+          (ALWAYS_INTERACTIVE_TOOLS.has(toolName) || EDIT_TOOLS.has(toolName))
+            ? "waiting"
+            : "running";
       } else if (hook_event_name === "PermissionRequest") {
         const toolName = typeof payload.tool_name === "string" ? payload.tool_name : "";
         displayEvent = toolName || hook_event_name;


### PR DESCRIPTION
## Summary

- Fix false "Waiting for input" status for `Edit`, `Write`, and `NotebookEdit` tools when session runs in `acceptEdits` permission mode
- Split `INTERACTIVE_TOOLS` into `ALWAYS_INTERACTIVE_TOOLS` (ExitPlanMode, AskUserQuestion) and `EDIT_TOOLS` (Write, Edit, NotebookEdit)
- Check `permission_mode` from hook payload to determine if edit tools are auto-approved

## Test plan

- [x] Edit/Write/NotebookEdit in `acceptEdits` mode → status stays "running"
- [x] Edit/Write in default mode → status transitions to "waiting"
- [x] AskUserQuestion/ExitPlanMode in `acceptEdits` mode → status still "waiting"
- [x] All 109 existing tests pass

Closes #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)